### PR TITLE
Large Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparc-design-system-nuxt3-module",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "The design system used by SPARC",
   "repository": "nih-sparc/sparc-design-system-nuxt3-module",
   "license": "MIT",
@@ -33,7 +33,8 @@
   "dependencies": {
     "@element-plus/nuxt": "^1.0.6",
     "@nuxt/kit": "^3.8.0",
-    "element-plus": "^2.4.2"
+    "element-plus": "^2.4.2",
+    "ramda": "^0.29.1"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -2,6 +2,46 @@
   <div>
     Nuxt module playground!
   </div>
+    <div>
+  <large-modal
+    :visible="dialogVisibleLarge"
+    @close-download-dialog="dialogVisibleLarge = false"
+  >
+    <template class="content" #optionalContent>
+      <h1>Direct download</h1>
+      <div>
+        <p>You can download the raw files and metadata directly to your computer as a zip archive free of charge.</p>
+        <p class="download-container__download-dataset-size">
+          Dataset Size: 17.43 GB
+        </p>
+        <el-button class="download-button">Download</el-button>
+      </div>
+    </template>
+    <template class="content" #mainContent>
+      <h1>Download from AWS</h1>
+      <p>
+        Raw files and metadata are stored in an AWS S3 Requester Pays bucket.
+        You can learn more about downloading data from AWS on our
+        <a href="/#" target="_blank">Help Page</a>.
+      </p>
+      <div>
+        <p>*Requester pays means that any costs associated with downloading the data will be charged to your AWS account.
+          For transfer pricing information, visit the <a href="https://aws.amazon.com/s3/pricing/" target="blank">AWS Pricing documentation.</a>
+        </p>
+        <div>
+        <el-button class="secondary" @click="dialogVisibleLarge = false">
+          Close
+        </el-button>
+        </div>
+      </div>
+    </template>
+  </large-modal>
+  <el-button
+    plain
+    @click="dialogVisibleLarge = true">
+    Open Large Modal
+  </el-button>
+
   <el-button class="custom">Test Button</el-button>
   <div class="container">
     <sparc-logo />
@@ -95,11 +135,13 @@
       </el-button>
     </template>
   </el-dialog>
+</div>
 </template>
 
 <script>
   import { ref } from 'vue'
   import { successMessage, infoMessage, failMessage, informationNotification, iconInformationNotification } from "./utils/notificationMessages.js"
+  import LargeModal from '../src/components/LargeModal.vue'
 
   const tableData = [{
     "id": 37,
@@ -339,49 +381,49 @@
   export default {
     name: 'App',
     setup() {
-      const tooltipDirs = ref([
-        'top-left',
-        'top-center',
-        'top-right',
-        'left-top',
-        'left-center',
-        'left-bottom',
-        'bottom-left',
-        'bottom-center',
-        'bottom-right',
-        'right-top',
-        'right-center',
-        'right-bottom'
-      ])
-      const dialogVisible = ref(false)
-
-      return {
-        dialogVisible,
-        tableData,
-        tooltipDirs
-      }
+        const tooltipDirs = ref([
+            'top-left',
+            'top-center',
+            'top-right',
+            'left-top',
+            'left-center',
+            'left-bottom',
+            'bottom-left',
+            'bottom-center',
+            'bottom-right',
+            'right-top',
+            'right-center',
+            'right-bottom'
+        ]);
+        const dialogVisible = ref(false);
+        const dialogVisibleLarge = ref(false);
+        return {
+            dialogVisible,
+            dialogVisibleLarge
+        };
     },
     methods: {
-      openSuccessMessage() {
-        successMessage(`Success!`)
-      },
-      openFailMessage() {
-        failMessage(`Failure.`)
-      },
-      openInfoMessage() {
-        infoMessage(`Information`)
-      },
-      openNotification() {
-        informationNotification('Notification Title', 'This is a notification.')
-      },
-      openNotificationWithIcon() {
-        iconInformationNotification('Notification Title', 'This is a notification with an icon.')
-      },
-      openDialog() {
-        this.dialogVisible = true
-      }
-    }
-  }
+        openSuccessMessage() {
+            successMessage(`Success!`);
+        },
+        openFailMessage() {
+            failMessage(`Failure.`);
+        },
+        openInfoMessage() {
+            infoMessage(`Information`);
+        },
+        openNotification() {
+            informationNotification('Notification Title', 'This is a notification.');
+        },
+        openNotificationWithIcon() {
+            iconInformationNotification('Notification Title', 'This is a notification with an icon.');
+        },
+        openDialog() {
+            this.dialogVisible = true;
+        }
+    },
+    components: { LargeModal }
+}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/LargeModal.vue
+++ b/src/components/LargeModal.vue
@@ -1,0 +1,120 @@
+<template>
+    <el-dialog 
+      :modelValue="visible"
+      :show-close="false"
+      class="sparc-design-system-large-modal-dialog"
+      @close="closeDialog"
+    >
+      <div class="dialog-container">
+
+        <div class="optional-content-container">
+          <slot name="optionalContent" />
+        </div>
+        <div class="main-content-container">
+          <slot name="mainContent" />
+        </div>
+      </div>
+    </el-dialog>
+  </template>
+  
+  <script>
+  
+  export default {
+    name: 'LargeModal',
+    props: {
+      visible: {
+        type: Boolean,
+        default: false
+      }
+    },
+  
+    setup(props, { emit }) {
+      function closeDialog() {
+        emit('close-download-dialog'); 
+      }
+      return {
+        closeDialog,
+      };
+    }
+  };
+  </script>
+  
+  <style lang="scss">
+
+  @import '../assets/_variables.scss';
+  .sparc-design-system-large-modal-dialog {
+      border-radius: 0;
+      width: fit-content;
+      max-width: 868px;
+    button:hover {
+      box-shadow: none;
+    }
+    .optional-content-container {
+      .download-button {
+        padding-top: 10px;
+        padding-bottom: 10px;
+        background: white !important;
+        text-align: center;
+        color: $purple !important;
+        min-width: 80px;
+      }
+      button:hover {
+        background: white;
+        color: $purple;
+      }
+    }
+
+      .el-dialog__body {
+        padding: 0;
+        color: black;
+      }
+  
+      .el-dialog__header {
+        display: none;
+      }
+  }
+  </style>
+  
+  <style lang="scss" scoped>
+  @import '../assets/_variables.scss';
+  
+  .sparc-design-system-large-modal-dialog {
+    .dialog-container {
+      display: flex;
+      word-break: normal;
+    }
+  
+    .main-content-container {
+      border: 1px solid $lineColor1;
+      border-left: none;
+      width: 100%;
+      padding: 2rem;
+    }
+  
+    .optional-content-container {
+      background-color: $purple;
+      box-sizing: border-box;
+      flex-shrink: 0;
+      color: #fff;
+      max-width: 316px;
+      min-width: min-content;
+      width: 35%;
+      overflow: hidden;
+      position: relative;
+      padding: 2rem;
+    }
+  
+    .optional-content-container:empty {
+      display: none;
+    }
+  
+    .close-dialog {
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: .25rem .25rem 0 0;
+      position: absolute;
+      right: 0;
+    }
+  }
+  </style>

--- a/src/components/LargeModal.vue
+++ b/src/components/LargeModal.vue
@@ -1,7 +1,7 @@
 <template>
     <el-dialog 
       :modelValue="visible"
-      :show-close="false"
+      :show-close="true"
       class="sparc-design-system-large-modal-dialog"
       @close="closeDialog"
     >
@@ -70,7 +70,7 @@
       }
   
       .el-dialog__header {
-        display: none;
+        padding: 0 !important;
       }
   }
   </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,6 +5163,11 @@ radix3@^1.1.0:
   resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.1.0.tgz#9745df67a49c522e94a33d0a93cf743f104b6e0d"
   integrity sha512-pNsHDxbGORSvuSScqNJ+3Km6QAVqk8CfsCBIEoDgpqLrkD2f3QM4I7d1ozJJ172OmIcoUcerZaNWqtLkRXTV3A==
 
+ramda@^0.29.1:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.1.tgz#408a6165b9555b7ba2fc62555804b6c5a2eca196"
+  integrity sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
Notes because there is no other file to compare:

I had to un-scope some el-dialog, el-dialog__body, and el-dialog__header styles. ::v-deep is deprecated and is now :deep() but I couldn't get that new syntax to select the element. Maybe Element Plus has changed something in that regard but I couldn't find anything. 

Close icon - had to change style from display:none to padding: 0 !important for show-close to style correctly 